### PR TITLE
Added "prepend" option for scratchbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## v0.0.2 (October 9, 2017)
+
+- Minor fixes
+
+## v0.0.1 (October 9, 2017)
+
+- Initial release.
+- `CMD+SHIFT+.` to open the scratchpad
+- Change `scratchpad.prepend` to true for prepend

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v.0.0.3 (October 23, 2017)
+
+- Minor documentation fixes, proper credit given
+
 ## v0.0.2 (October 9, 2017)
 
 - Minor fixes

--- a/README.md
+++ b/README.md
@@ -1,17 +1,20 @@
 # Scratchpad README
 
-Simple Scratchpad for quick notes.
+Simple Scratchpad for quick notes. 
 
-# Usage
+By default, notes are appended to the same document regardless of where you are in VSCode, and are optionally prepended if you'd like to keep a reverse-chronological history of your scratchpad. Timestamps are added for visual clarity. If you delete the scratchpad file, upon next run it will generate a new file for you to use.
+
+## Usage
 
 1. Install the plugin (reload VS Code)
-2. Press F1, search for `Open Scratchpad`
+2. `CMD+SHIFT+P`, search for `Open Scratchpad`
 3. Add key bindings (Optional) .
     - Open key bindings settings file:
         + Open Command Palette (Ctrl+P)
         + Search for 'Open keyboard shortcuts'
     - Add and save you key bindings. For example:
-```
+
+```json
 // Open "keybindings.json" to overwrite the defaults. Can also be modified in VS Code's Keyboard Preferences.
 [
     {
@@ -21,10 +24,23 @@ Simple Scratchpad for quick notes.
     }
 ]
 ```
-4. Settings can be modified to specify appending to scratchpad upon invocation or prepending (defaults to appending):
-```
-// Setting for prepending to scratchpad.txt
 
+4. Settings can be modified to specify appending to scratchpad upon invocation or prepending (defaults to appending):
+
+```json
+// Setting for prepending to scratchpad.txt
 "scratchpad.prepend": true // default is false
 ```
-5. Enjoy! :)
+
+## Contributing
+
+1. Clone the repo
+2. `$ npm install`
+3. Develop develop develop
+4. Run the tsc linter
+5. Open a PR and I'll take a look
+
+
+## History
+
+- 0.0.1 - Initial release

--- a/README.md
+++ b/README.md
@@ -45,3 +45,7 @@ By default, notes are appended to the same document regardless of where you are 
 
 - 0.0.1 - Initial release
 - 0.0.2 - Updates to README, `package.json`
+
+## Acknowledgements
+
+- This extension was forked from [awesomektvn's vscode-scratchpad plugin.](https://github.com/awesomektvn/vscode-scratchpad) As he was not responding to a PR, I have begin maintaining my own fork.

--- a/README.md
+++ b/README.md
@@ -44,3 +44,4 @@ By default, notes are appended to the same document regardless of where you are 
 ## History
 
 - 0.0.1 - Initial release
+- 0.0.2 - Updates to README, `package.json`

--- a/README.md
+++ b/README.md
@@ -3,17 +3,28 @@
 Simple Scratchpad for quick notes.
 
 # Usage
-1. Install this plugin :)
-2. Press F1, search for "Scratchpad"
+
+1. Install the plugin (reload VS Code)
+2. Press F1, search for `Open Scratchpad`
 3. Add key bindings (Optional) .
     - Open key bindings settings file:
         + Open Command Palette (Ctrl+P)
         + Search for 'Open keyboard shortcuts'
     - Add and save you key bindings. For example:
 ```
-// Place your key bindings in this file to overwrite the defaults
+// Open "keybindings.json" to overwrite the defaults. Can also be modified in VS Code's Keyboard Preferences.
 [
-    { "key": "ctrl+shift+.",   "command": "extension.openScratchpad", "when": "editorTextFocus" }
+    {
+        "key": "ctrl+shift+.",
+        "command": "extension.openScratchpad",
+        "when": "editorTextFocus"
+    }
 ]
 ```
-4. Enjoy! :)
+4. Settings can be modified to specify appending to scratchpad upon invocation or prepending (defaults to appending):
+```
+// Setting for prepending to scratchpad.txt
+
+"scratchpad.prepend": true // default is false
+```
+5. Enjoy! :)

--- a/package.json
+++ b/package.json
@@ -1,11 +1,16 @@
 {
   "name": "scratchpad",
   "displayName": "Scratchpad",
-  "description": "a simple scratchpad for vscode",
-  "version": "0.0.1",
-  "publisher": "awesomektvn",
+  "description": "Simple Scratchpad for quick notes.",
+  "version": "0.0.2",
+  "publisher": "macintacos",
   "engines": {
     "vscode": "^1.0.0"
+  },
+  "homepage": "https://github.com/macintacos/vscode-scratchpad",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/macintacos/vscode-scratchpad.git"
   },
   "categories": ["Other"],
   "activationEvents": ["onCommand:extension.openScratchpad"],
@@ -25,13 +30,13 @@
           "type": "boolean",
           "default": false,
           "description":
-            "Specifies whether or not you want to prepend notes to your scracthpad, rather than the default append. Timestamp will be placed at the top of the file, with the cursor inserted just beneath it."
+            "Specifies whether or not you want to prepend notes to your scratchpad, rather than the default append. Timestamp will be placed at the top of the file, with the cursor inserted just beneath it."
         }
       }
     }
   },
   "scripts": {
-    "vscode:prepublish": "node ./node_modules/vscode/bin/compile",
+    "vscode:prepublish": "",
     "compile": "node ./node_modules/vscode/bin/compile -watch -p ./",
     "postinstall": "node ./node_modules/vscode/bin/install"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "scratchpad",
   "displayName": "Scratchpad",
   "description": "Simple Scratchpad for quick notes.",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "publisher": "macintacos",
   "engines": {
     "vscode": "^1.0.0"
@@ -16,12 +16,10 @@
   "activationEvents": ["onCommand:extension.openScratchpad"],
   "main": "./out/src/extension",
   "contributes": {
-    "commands": [
-      {
-        "command": "extension.openScratchpad",
-        "title": "Open Scratchpad"
-      }
-    ],
+    "commands": [{
+      "command": "extension.openScratchpad",
+      "title": "Open Scratchpad"
+    }],
     "configuration": {
       "type": "object",
       "title": "Scratchpad Config",
@@ -29,8 +27,7 @@
         "scratchpad.prepend": {
           "type": "boolean",
           "default": false,
-          "description":
-            "Specifies whether or not you want to prepend notes to your scratchpad, rather than the default append. Timestamp will be placed at the top of the file, with the cursor inserted just beneath it."
+          "description": "Specifies whether or not you want to prepend notes to your scratchpad, rather than the default append. Timestamp will be placed at the top of the file, with the cursor inserted just beneath it."
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scratchpad",
-  "displayName": "scratchpad",
+  "displayName": "Scratchpad",
   "description": "a simple scratchpad for vscode",
   "version": "0.0.1",
   "publisher": "awesomektvn",

--- a/package.json
+++ b/package.json
@@ -1,32 +1,42 @@
 {
-    "name": "scratchpad",
-    "displayName": "Scratchpad",
-    "description": "a simple scratchpad for vscode",
-    "version": "0.0.1",
-    "publisher": "awesomektvn",
-    "engines": {
-        "vscode": "^1.0.0"
-    },
-    "categories": [
-        "Other"
+  "name": "scratchpad",
+  "displayName": "scratchpad",
+  "description": "a simple scratchpad for vscode",
+  "version": "0.0.1",
+  "publisher": "awesomektvn",
+  "engines": {
+    "vscode": "^1.0.0"
+  },
+  "categories": ["Other"],
+  "activationEvents": ["onCommand:extension.openScratchpad"],
+  "main": "./out/src/extension",
+  "contributes": {
+    "commands": [
+      {
+        "command": "extension.openScratchpad",
+        "title": "Open Scratchpad"
+      }
     ],
-    "activationEvents": [
-        "onCommand:extension.openScratchpad"
-    ],
-    "main": "./out/src/extension",
-    "contributes": {
-        "commands": [{
-            "command": "extension.openScratchpad",
-            "title": "Open Scratchpad"
-        }]
-    },
-    "scripts": {
-        "vscode:prepublish": "node ./node_modules/vscode/bin/compile",
-        "compile": "node ./node_modules/vscode/bin/compile -watch -p ./",
-        "postinstall": "node ./node_modules/vscode/bin/install"
-    },
-    "devDependencies": {
-        "typescript": "^1.8.5",
-        "vscode": "^0.11.0"
+    "configuration": {
+      "type": "object",
+      "title": "Scratchpad Config",
+      "properties": {
+        "scratchpad.prepend": {
+          "type": "boolean",
+          "default": false,
+          "description":
+            "Specifies whether or not you want to prepend notes to your scracthpad, rather than the default append. Timestamp will be placed at the top of the file, with the cursor inserted just beneath it."
+        }
+      }
     }
+  },
+  "scripts": {
+    "vscode:prepublish": "node ./node_modules/vscode/bin/compile",
+    "compile": "node ./node_modules/vscode/bin/compile -watch -p ./",
+    "postinstall": "node ./node_modules/vscode/bin/install"
+  },
+  "devDependencies": {
+    "typescript": "^1.8.5",
+    "vscode": "^0.11.0"
+  }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -50,11 +50,11 @@ export function deactivate() {}
 function newLine(firstLine = false) {
   const now = new Date();
   let datestamp =
-    "----------" +
+    "__________ " +
     now.toJSON().slice(0, 10) +
     " " +
     now.toLocaleTimeString("fullwise", { hour12: false }) +
-    "----------";
+    " __________";
   var fullText = prepend
     ? (firstLine ? "" : EOL) + datestamp + EOL + "\n"
     : (firstLine ? "" : EOL) + datestamp + EOL;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,44 +1,63 @@
-'use strict';
-import * as vscode from 'vscode';
 import * as fs from 'fs';
+import { EOL } from 'os';
 import * as path from 'path';
-import {EOL} from 'os';
+import * as vscode from 'vscode';
 
-const fileName = 'scratchpad.txt';
-let fullPath = '';
+"use strict";
+const fileName = "scratchpad.txt";
+let fullPath = "";
+let prepend = vscode.workspace.getConfiguration("scratchpad").prepend;
 
 export function activate(context: vscode.ExtensionContext) {
+  let scratchpad = vscode.commands.registerCommand(
+    "extension.openScratchpad",
+    () => {
+      fullPath = path.join(context.extensionPath, fileName);
+      if (!fs.existsSync(fullPath)) {
+        fs.writeFileSync(fullPath, "");
+      }
 
-    let disposable = vscode.commands.registerCommand('extension.openScratchpad', () => {
+      vscode.workspace.openTextDocument(fullPath).then(doc => {
+        vscode.window.showTextDocument(doc).then(editor => {
+          const length = prepend ? 0 : doc.getText().length;
+          const pos = editor.document.positionAt(length);
 
-        fullPath = path.join(context.extensionPath, fileName);
-        if (!fs.existsSync(fullPath)) {
-            fs.writeFileSync(fullPath, '');
-        }
+          editor.selection = new vscode.Selection(pos, pos);
+          editor.edit(e => {
+            e.insert(pos, newLine(length === 0));
+          });
 
-        vscode.workspace.openTextDocument(fullPath).then((doc) => {
-            vscode.window.showTextDocument(doc).then(editor => {
-                const length = doc.getText().length;
-                const pos = editor.document.positionAt(length);
-                editor.selection = new vscode.Selection(pos, pos);
-                editor.edit(e => {
-                    e.insert(pos, newLine(length === 0));
-                });
-            });
+          if (prepend) {
+            let prependPosition = editor.document.positionAt(
+              newLine(length === 0).length
+            );
+
+            editor.selection = new vscode.Selection(
+              prependPosition,
+              prependPosition
+            );
+          }
         });
-    });
+      });
+    }
+  );
 
-    context.subscriptions.push(disposable);
+  context.subscriptions.push(scratchpad);
 }
 
-export function deactivate() {
-}
+export function deactivate() {}
 
 function newLine(firstLine = false) {
-    const now = new Date();
-    return (firstLine ? '' : EOL)
-        + '----------'
-        + now.toJSON().slice(0, 10) + ' '
-        + now.toLocaleTimeString('fullwise', {hour12: false})
-        + '----------' + EOL;
+  const now = new Date();
+  let datestamp =
+    "----------" +
+    now.toJSON().slice(0, 10) +
+    " " +
+    now.toLocaleTimeString("fullwise", { hour12: false }) +
+    "----------";
+  var fullText = prepend
+    ? (firstLine ? "" : EOL) + datestamp + EOL + "\n"
+    : (firstLine ? "" : EOL) + datestamp + EOL;
+
+  return fullText;
 }


### PR DESCRIPTION
I really liked the simple implementation of this scratchpad, however I wanted to always be at the top of the file when creating a new piece of scratch with the timestamp. I like the timestamp idea, so I wanted to implement it but place it at the top of the file and push all of the previous content down. It's an option currently, and can be enabled by going into settings and changing `scratchpad.prepend` from `false` to `true`.

As it's your extension, I wanted to merge instead of creating a separate extension. Could you take a look and merge/push to the Extensions Marketplace?